### PR TITLE
Update `brew install` syntax

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -141,7 +141,7 @@ class Index extends React.Component {
                   <span>dmg</span>
                 </a>
                 <p className='content is-light'>
-                  or <code>brew cask install mockoon</code>
+                  or <code>brew install --cask mockoon</code>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
`brew cask install` has been deprecated since the start of December, with [2.6's release](https://brew.sh/2020/12/01/homebrew-2.6.0/) and then [disabled in 2.7](https://brew.sh/2020/12/21/homebrew-2.7.0/) at the end of December.

Brew self-updates so most/all users will be on the latest version.