### PR TITLE
fix: Fix closing tag in switch case example docs

### DIFF
--- a/content/docs/latest/templating/mockoon-helpers.md
+++ b/content/docs/latest/templating/mockoon-helpers.md
@@ -79,7 +79,7 @@ Select some content depending on a variable. Behaves like a regular switch.
   {{# case "1" }}"John"{{/ case }}
   {{# case "2" }}"Jack"{{/ case }}
   {{# default }}"Peter"{{/ default }}
-{{# /}}
+{{/ switch}}
 ```
 
 ## `array`

--- a/content/docs/v1.13.0/templating/mockoon-helpers.md
+++ b/content/docs/v1.13.0/templating/mockoon-helpers.md
@@ -70,7 +70,7 @@ Select some content depending on a variable. Behaves like a regular switch.
   {{# case "1" }}"John"{{/ case }}
   {{# case "2" }}"Jack"{{/ case }}
   {{# default }}"Peter"{{/ default }}
-{{# /}}
+{{/ switch}}
 ```
 
 ## `array`

--- a/content/docs/v1.14.0/templating/mockoon-helpers.md
+++ b/content/docs/v1.14.0/templating/mockoon-helpers.md
@@ -75,7 +75,7 @@ Select some content depending on a variable. Behaves like a regular switch.
   {{# case "1" }}"John"{{/ case }}
   {{# case "2" }}"Jack"{{/ case }}
   {{# default }}"Peter"{{/ default }}
-{{# /}}
+{{/ switch}}
 ```
 
 ## `array`

--- a/content/docs/v1.15.0/templating/mockoon-helpers.md
+++ b/content/docs/v1.15.0/templating/mockoon-helpers.md
@@ -76,7 +76,7 @@ Select some content depending on a variable. Behaves like a regular switch.
   {{# case "1" }}"John"{{/ case }}
   {{# case "2" }}"Jack"{{/ case }}
   {{# default }}"Peter"{{/ default }}
-{{# /}}
+{{/ switch}}
 ```
 
 ## `array`

--- a/content/docs/v1.16.0/templating/mockoon-helpers.md
+++ b/content/docs/v1.16.0/templating/mockoon-helpers.md
@@ -76,7 +76,7 @@ Select some content depending on a variable. Behaves like a regular switch.
   {{# case "1" }}"John"{{/ case }}
   {{# case "2" }}"Jack"{{/ case }}
   {{# default }}"Peter"{{/ default }}
-{{# /}}
+{{/ switch}}
 ```
 
 ## `array`

--- a/content/docs/v1.17.0/templating/mockoon-helpers.md
+++ b/content/docs/v1.17.0/templating/mockoon-helpers.md
@@ -79,7 +79,7 @@ Select some content depending on a variable. Behaves like a regular switch.
   {{# case "1" }}"John"{{/ case }}
   {{# case "2" }}"Jack"{{/ case }}
   {{# default }}"Peter"{{/ default }}
-{{# /}}
+{{/ switch}}
 ```
 
 ## `array`


### PR DESCRIPTION
<!-- 
IMPORTANT RULES: 
- Read the contributing guidelines first!
- All pull requests must be linked to an issue.
- Follow the branch naming convention.
- Follow the template!
 -->

**Parent issue** 

Closes #90

## Questions:

* I updated the tag in all versions of the documentation, although I have only tested it in 1.18.1. Not sure if anything has changed. 
* I am unable to install next and therefore build the site, so have not been able to verify the end result.  
