### PR TITLE
Fix Faker.js version and url

### DIFF
--- a/content/docs/latest/templating/fakerjs-helpers.md
+++ b/content/docs/latest/templating/fakerjs-helpers.md
@@ -10,7 +10,7 @@ order: 1040
 
 ---
 
-Mockoon implements [Faker.js v6.3.1](https://fakerjs.dev/) library by wrapping most of the available helpers.
+Mockoon implements [Faker.js v7.6.0](https://fakerjs.dev/) library by wrapping most of the available helpers.
 Faker.js offers lots of helpers: `address.zipCode`, `address.city`, `address.cityPrefix`, `name.firstName`, `name.lastName`, `datatype.number`, `datatype.float`, `internet.avatar`, `internet.email`, etc. Please have a look at [Faker.js documentation](https://fakerjs.dev/) to learn how to use them.
 
 ## Usage

--- a/content/docs/latest/templating/overview.md
+++ b/content/docs/latest/templating/overview.md
@@ -10,7 +10,7 @@ order: 1000
 
 ---
 
-Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v5.5.3](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
+Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v7.6.0](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
 
 ## Helpers
 

--- a/content/docs/v1.19.0/templating/fakerjs-helpers.md
+++ b/content/docs/v1.19.0/templating/fakerjs-helpers.md
@@ -10,8 +10,8 @@ order: 1030
 
 ---
 
-Mockoon implements [Faker.js v6.3.1](https://fakerjs.dev/) library by wrapping most of the available helpers.
-Faker.js offers lots of helpers: `address.zipCode`, `address.city`, `address.cityPrefix`, `name.firstName`, `name.lastName`, `datatype.number`, `datatype.float`, `internet.avatar`, `internet.email`, etc. Please have a look at [Faker.js documentation](https://fakerjs.dev/) to learn how to use them.
+Mockoon implements [Faker.js v6.3.1](https://v6.fakerjs.dev/) library by wrapping most of the available helpers.
+Faker.js offers lots of helpers: `address.zipCode`, `address.city`, `address.cityPrefix`, `name.firstName`, `name.lastName`, `datatype.number`, `datatype.float`, `internet.avatar`, `internet.email`, etc. Please have a look at [Faker.js documentation](https://v6.fakerjs.dev/) to learn how to use them.
 
 ## Usage
 

--- a/content/docs/v1.19.0/templating/overview.md
+++ b/content/docs/v1.19.0/templating/overview.md
@@ -10,7 +10,7 @@ order: 1000
 
 ---
 
-Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v5.5.3](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
+Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v6.3.1](https://v6.fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
 
 ## Helpers
 

--- a/content/docs/v1.20.0/templating/fakerjs-helpers.md
+++ b/content/docs/v1.20.0/templating/fakerjs-helpers.md
@@ -10,8 +10,8 @@ order: 1030
 
 ---
 
-Mockoon implements [Faker.js v6.3.1](https://fakerjs.dev/) library by wrapping most of the available helpers.
-Faker.js offers lots of helpers: `address.zipCode`, `address.city`, `address.cityPrefix`, `name.firstName`, `name.lastName`, `datatype.number`, `datatype.float`, `internet.avatar`, `internet.email`, etc. Please have a look at [Faker.js documentation](https://fakerjs.dev/) to learn how to use them.
+Mockoon implements [Faker.js v6.3.1](https://v6.fakerjs.dev/) library by wrapping most of the available helpers.
+Faker.js offers lots of helpers: `address.zipCode`, `address.city`, `address.cityPrefix`, `name.firstName`, `name.lastName`, `datatype.number`, `datatype.float`, `internet.avatar`, `internet.email`, etc. Please have a look at [Faker.js documentation](https://v6.fakerjs.dev/) to learn how to use them.
 
 ## Usage
 

--- a/content/docs/v1.20.0/templating/overview.md
+++ b/content/docs/v1.20.0/templating/overview.md
@@ -10,7 +10,7 @@ order: 1000
 
 ---
 
-Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v5.5.3](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
+Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v6.3.1](https://v6.fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
 
 ## Helpers
 

--- a/content/docs/v1.21.1/templating/fakerjs-helpers.md
+++ b/content/docs/v1.21.1/templating/fakerjs-helpers.md
@@ -10,7 +10,7 @@ order: 1030
 
 ---
 
-Mockoon implements [Faker.js v6.3.1](https://fakerjs.dev/) library by wrapping most of the available helpers.
+Mockoon implements [Faker.js v7.6.0](https://fakerjs.dev/) library by wrapping most of the available helpers.
 Faker.js offers lots of helpers: `address.zipCode`, `address.city`, `address.cityPrefix`, `name.firstName`, `name.lastName`, `datatype.number`, `datatype.float`, `internet.avatar`, `internet.email`, etc. Please have a look at [Faker.js documentation](https://fakerjs.dev/) to learn how to use them.
 
 ## Usage

--- a/content/docs/v1.21.1/templating/overview.md
+++ b/content/docs/v1.21.1/templating/overview.md
@@ -10,7 +10,7 @@ order: 1000
 
 ---
 
-Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v5.5.3](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
+Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v7.6.0](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
 
 ## Helpers
 

--- a/content/docs/v1.22.0/templating/fakerjs-helpers.md
+++ b/content/docs/v1.22.0/templating/fakerjs-helpers.md
@@ -10,7 +10,7 @@ order: 1040
 
 ---
 
-Mockoon implements [Faker.js v6.3.1](https://fakerjs.dev/) library by wrapping most of the available helpers.
+Mockoon implements [Faker.js v7.6.0](https://fakerjs.dev/) library by wrapping most of the available helpers.
 Faker.js offers lots of helpers: `address.zipCode`, `address.city`, `address.cityPrefix`, `name.firstName`, `name.lastName`, `datatype.number`, `datatype.float`, `internet.avatar`, `internet.email`, etc. Please have a look at [Faker.js documentation](https://fakerjs.dev/) to learn how to use them.
 
 ## Usage

--- a/content/docs/v1.22.0/templating/overview.md
+++ b/content/docs/v1.22.0/templating/overview.md
@@ -10,7 +10,7 @@ order: 1000
 
 ---
 
-Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v5.5.3](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
+Mockoon implements [Handlebars](https://handlebarsjs.com/), [Faker.js v7.6.0](https://fakerjs.dev/), and a set of custom helpers to create dynamic responses. This templating system is supported in the response's **body**, **headers**, **file content**, and **file path**. You will find below a global overview of how and where you can use helpers. You can also check the [available helpers](#available-helpers) on specific documentation pages.
 
 ## Helpers
 

--- a/content/releases/desktop/1.19.0.md
+++ b/content/releases/desktop/1.19.0.md
@@ -47,7 +47,7 @@ Defining the default response is now easier. Before this change, the default res
 
 We added new templating helpers: [`lowercase`](https://mockoon.com/docs/latest/templating/mockoon-helpers/#lowercase), [`uppercase`](https://mockoon.com/docs/latest/templating/mockoon-helpers/#uppercase), and [`base64Decode`](https://mockoon.com/docs/latest/templating/mockoon-helpers/#base64Decode). (Issues [#655](https://github.com/mockoon/mockoon/issues/655) and [#625](https://github.com/mockoon/mockoon/issues/625))
 
-We also updated [Faker.js](https://fakerjs.dev/) to version 6. It offers some new helpers and locales. (Issue [#716](https://github.com/mockoon/mockoon/issues/716))
+We also updated [Faker.js](https://v6.fakerjs.dev/) to version 6. It offers some new helpers and locales. (Issue [#716](https://github.com/mockoon/mockoon/issues/716))
 
 ## Copy an endpoint full path
 


### PR DESCRIPTION
This aligns faker.js version + url for all documented versions of mockoon.

**Parent issue** 

Closes #103 